### PR TITLE
Update to Minecraft 1.18.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,8 +3,8 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://modmuss50.me/fabric.html
-minecraft_version=1.18.1
-yarn_mappings=1.18.1+build.22
+minecraft_version=1.18.2
+yarn_mappings=1.18.2+build.4
 loader_version=0.14.9
 
 # Mod Properties
@@ -14,6 +14,6 @@ archives_base_name=default-servers
 
 # Dependencies
 # check this on https://modmuss50.me/fabric.html
-fabric_version=0.46.6+1.18
+fabric_version=0.59.1+1.18.2
 
-omega_config_version=1.2.3-1.18.1
+omega_config_version=1.2.3-1.18.2


### PR DESCRIPTION
This updates `default-servers` to Minecraft 1.18.2.

With Draylar/omega-config#23 merged (the only dependency which was not yet 1.18.2 compatible) `default-servers` can now also be updated to 1.18.2.